### PR TITLE
renderer config option

### DIFF
--- a/src/generateImage.js
+++ b/src/generateImage.js
@@ -11,6 +11,7 @@ const defaultOpts = {
     width: 800,
     height: 600,
   },
+  renderer: undefined,
   image: {
     path: undefined,
   },
@@ -18,7 +19,7 @@ const defaultOpts = {
 
 const generateImage = async function(component, options) {
   const opts = merge(defaultOpts, options);
-  const template = await renderTemplate(component, opts.stylesheet);
+  const template = await renderTemplate(component, opts.stylesheet, opts.renderer);
   return await takeScreenshot(template, opts);
 };
 

--- a/src/lib/renderComponent.js
+++ b/src/lib/renderComponent.js
@@ -1,8 +1,8 @@
 const ReactDOMServer = require('react-dom/server')
 
-module.exports = function (component) {
+module.exports = function (component, renderer = ReactDOMServer.renderToStaticMarkup) {
   try {
-    const renderedComponent = ReactDOMServer.renderToStaticMarkup(component)
+    const renderedComponent = renderer(component)
     return renderedComponent
   } catch (e) {
     throw Error('Not a valid React component')

--- a/src/lib/renderTemplate.js
+++ b/src/lib/renderTemplate.js
@@ -13,9 +13,9 @@ nunjucks.configure(tplOpts.path, {
   autoescape: true
 })
 
-module.exports = async function (component, stylesheet) {
+module.exports = async function (component, stylesheet, renderer) {
   const template = nunjucks.render(tplOpts.view, {
-    component: await renderComponent(component),
+    component: await renderComponent(component, renderer),
     styles: await parseStyleSheet(stylesheet)
   })
 


### PR DESCRIPTION
Allow a custom render function in config instead of ReactDOMServer.renderToStaticMarkup.

This adds support for [CSSinJS](https://medium.com/seek-blog/a-unified-styling-language-d0c208de2660) libraries such as [Glamorous](https://glamorous.rocks), that need styles to be rendered alongside the component element.

```
import renderGlamorous from "render-glamorous";

generateImage(component, {
  renderer: renderGlamorous
})
```

https://github.com/penx/render-glamorous