### PR TITLE
Change node version in engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "standard": "^10.0.3"
   },
   "engines": {
-    "node": "8.9.4"
+    "node": ">=8"
   },
   "jest": {
     "collectCoverage": true


### PR DESCRIPTION
yarn will currently fail to install component-image unless you are using exactly the node version specified.

Instead, require an engine of node >=8