### PR TITLE
Add puppeteerOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ options = {
   image: {
     // Path to save image, likely unnecessary
     path: undefined,
-  }
+  },
+  // Options that are passed to Puppeteer
+  puppeteerOptions: {}
 }
 ```
 

--- a/src/generateImage.js
+++ b/src/generateImage.js
@@ -15,6 +15,7 @@ const defaultOpts = {
   image: {
     path: undefined,
   },
+  puppeteerOptions: {},
 };
 
 const generateImage = async function(component, options) {

--- a/src/lib/takeScreenshot.js
+++ b/src/lib/takeScreenshot.js
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer');
 
 module.exports = async function(template, opts) {
-  const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch(opts.puppeteerOptions);
   const page = await browser.newPage();
   await page.setContent(template);
   await page.setViewport(opts.viewport);


### PR DESCRIPTION
These are needed on some environments, for example Travis CI.

See https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md

Usage example:

```javascript
generateImage(component, {
    puppeteerOptions: { args: ["--no-sandbox"] }
});
```